### PR TITLE
Treat semicolons as a delimiter outside of groups.

### DIFF
--- a/src/addressparser.js
+++ b/src/addressparser.js
@@ -237,7 +237,15 @@
         "(": ")",
         "<": ">",
         ",": "",
-        ":": ";"
+        // Groups are ended by semicolons
+        ":": ";",
+        // Semicolons are not a legal delimiter per the RFC2822 grammar other
+        // than for terminating a group, but they are also not valid for any
+        // other use in this context.  Given that some mail clients have
+        // historically allowed the semicolon as a delimiter equivalent to the
+        // comma in their UI, it makes sense to treat them the same as a comma
+        // when used outside of a group.
+        ";": ""
     };
 
     /**

--- a/test/addressparser-unit.js
+++ b/test/addressparser-unit.js
@@ -53,6 +53,15 @@
                 expect(addressparser.parse(input)).to.deep.equal(expected);
             });
 
+            it("should handle quoted semicolons correctly", function() {
+                var input = "\"reinman; andris\" <andris@tr.ee>",
+                    expected = [{
+                        name: "reinman; andris",
+                        address: "andris@tr.ee"
+                    }];
+                expect(addressparser.parse(input)).to.deep.equal(expected);
+            });
+
             it("should handle unquoted name, unquoted address correctly", function() {
                 var input = "andris andris@tr.ee",
                     expected = [{
@@ -86,6 +95,18 @@
                 expect(addressparser.parse(input)).to.deep.equal(expected);
             });
 
+            it("should handle semicolon as a delimiter", function() {
+                var input = "andris@tr.ee; andris@example.com;",
+                    expected = [{
+                        address: "andris@tr.ee",
+                        name: ""
+                    }, {
+                        address: "andris@example.com",
+                        name: ""
+                    }];
+                expect(addressparser.parse(input)).to.deep.equal(expected);
+            });
+
             it("should handle mixed group correctly", function() {
                 var input = "Test User <test.user@mail.ee>, Disclosed:andris@tr.ee, andris@example.com;,,,, Undisclosed:;",
                     expected = [{
@@ -103,6 +124,30 @@
                     }, {
                         "name": "Undisclosed",
                         "group": []
+                    }];
+                expect(addressparser.parse(input)).to.deep.equal(expected);
+            });
+
+            it("semicolon as delimiter should not break group parsing ", function() {
+                var input = "Test User <test.user@mail.ee>; Disclosed:andris@tr.ee, andris@example.com;,,,, Undisclosed:; bob@example.com;",
+                    expected = [{
+                        "address": "test.user@mail.ee",
+                        "name": "Test User"
+                    }, {
+                        "name": "Disclosed",
+                        "group": [{
+                            "address": "andris@tr.ee",
+                            "name": ""
+                        }, {
+                            "address": "andris@example.com",
+                            "name": ""
+                        }]
+                    }, {
+                        "name": "Undisclosed",
+                        "group": []
+                    }, {
+                        "address": "bob@example.com",
+                        "name": ""
                     }];
                 expect(addressparser.parse(input)).to.deep.equal(expected);
             });


### PR DESCRIPTION
This patch modifies addressparser to treat semicolons like commas when used
outside of a group.  I believe this may have been the original intent of
addressparser since there is explicit logic in addressparser.parse that already
treats semicolons identically to commas.

Context: In the Firefox OS email app we allow the user to use the semicolon
character to act as a delimiter in the UI for consistency with other email
client UIs and because there is no valid use for the semicolon apart from a
delimiter in that context.  The app currently depends on addressparser to treat
the semicolon as a delimiter identical to a comma when used outside of a group,
but addressparser does not.  I think it makes more sense to address this in
addressparser than in our UI in this situation, but we can also do that.

(Note that this was a regression in our UI, but it was probably due to the
change to have our UI use addressparser directly rather than the very naive
approach we were using previously that just looked for commas and spaces and
semicolons.)